### PR TITLE
Numeric widget and localized number formatting.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,8 +4,8 @@ dependencies {
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev')
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.7.1:dev')
 
-    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha33:api') { transitive = false }
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.92:dev')
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha34:api') { transitive = false }
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.95:dev')
     api("com.github.GTNewHorizons:TecTech:5.3.32:dev")
     api("com.github.GTNewHorizons:GalacticGregGT5:1.1.0:dev") {
         exclude group:"com.github.GTNewHorizons", module:"bartworks"

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,7 +1,7 @@
 // Add your dependencies here
 
 dependencies {
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.92:dev')
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.95:dev')
     api("com.github.GTNewHorizons:TecTech:5.3.32:dev")
     api("com.github.GTNewHorizons:GalacticGregGT5:1.1.0:dev") {
         exclude group:"com.github.GTNewHorizons", module:"bartworks"

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_LESU.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_LESU.java
@@ -530,19 +530,19 @@ public class GT_TileEntity_LESU extends GT_MetaTileEntity_MultiBlockBase {
                                 () -> this.getBaseMetaTileEntity().getInputVoltage(),
                                 val -> clientMaxIn = val))
                 .widget(
-                    new TextWidget().setStringSupplier(() -> "EU/t OUT: " + numberFormat.format(clientMaxOut))
-                        .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
+                        new TextWidget().setStringSupplier(() -> "EU/t OUT: " + numberFormat.format(clientMaxOut))
+                                .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
                 .widget(
-                    new FakeSyncWidget.LongSyncer(
-                        () -> this.getBaseMetaTileEntity().getOutputVoltage(),
-                        val -> clientMaxOut = val))
+                        new FakeSyncWidget.LongSyncer(
+                                () -> this.getBaseMetaTileEntity().getOutputVoltage(),
+                                val -> clientMaxOut = val))
                 .widget(
-                    new TextWidget().setStringSupplier(() -> "AMP/t IN/OUT: " + numberFormat.format(clientAmps))
-                        .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
+                        new TextWidget().setStringSupplier(() -> "AMP/t IN/OUT: " + numberFormat.format(clientAmps))
+                                .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
                 .widget(
-                    new FakeSyncWidget.LongSyncer(
-                        () -> this.getBaseMetaTileEntity().getInputAmperage(),
-                        val -> clientAmps = val))
+                        new FakeSyncWidget.LongSyncer(
+                                () -> this.getBaseMetaTileEntity().getInputAmperage(),
+                                val -> clientAmps = val))
                 .widget(
                         new TextWidget(Text.localised("tooltip.LESU.0.name")).setDefaultColor(Color.YELLOW.getRGB())
                                 .setEnabled(widget -> this.maxEUStore() >= Long.MAX_VALUE - 1))

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_LESU.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/GT_TileEntity_LESU.java
@@ -34,6 +34,7 @@ import com.github.bartimaeusnek.bartworks.common.loaders.ItemRegistry;
 import com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference;
 import com.github.bartimaeusnek.bartworks.util.ChatColorHelper;
 import com.github.bartimaeusnek.bartworks.util.ConnectedBlocksChecker;
+import com.gtnewhorizons.modularui.api.NumberFormatMUI;
 import com.gtnewhorizons.modularui.api.drawable.Text;
 import com.gtnewhorizons.modularui.api.forge.ItemStackHandler;
 import com.gtnewhorizons.modularui.api.screen.ModularWindow;
@@ -41,6 +42,7 @@ import com.gtnewhorizons.modularui.api.screen.UIBuildContext;
 import com.gtnewhorizons.modularui.common.internal.wrapper.BaseSlot;
 import com.gtnewhorizons.modularui.common.widget.DrawableWidget;
 import com.gtnewhorizons.modularui.common.widget.DynamicPositionedColumn;
+import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar;
 import com.gtnewhorizons.modularui.common.widget.SlotWidget;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
@@ -78,6 +80,8 @@ public class GT_TileEntity_LESU extends GT_MetaTileEntity_MultiBlockBase {
         }
     };
     private long mStorage;
+
+    protected static final NumberFormatMUI numberFormat = new NumberFormatMUI();
 
     public GT_TileEntity_LESU(int aID, String aName, String aNameRegional) {
         super(aID, aName, aNameRegional);
@@ -492,39 +496,53 @@ public class GT_TileEntity_LESU extends GT_MetaTileEntity_MultiBlockBase {
                                 .setSize(116, 5));
     }
 
+    private long clientEU;
+    private long clientMaxEU;
+    private long clientMaxIn;
+    private long clientMaxOut;
+    private long clientAmps;
+
     private void drawTexts(DynamicPositionedColumn screenElements) {
         screenElements.setSpace(0).setPos(11, 8);
 
         screenElements
                 .widget(
-                        TextWidget.dynamicString(
-                                () -> "EU: " + GT_Utility.formatNumbers(this.getBaseMetaTileEntity().getStoredEU()))
+                        new TextWidget().setStringSupplier(() -> "EU: " + numberFormat.format(this.clientEU))
                                 .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
                 .widget(
-                        TextWidget.dynamicString(
-                                () -> "MAX: " + (this.getBaseMetaTileEntity().isActive()
-                                        ? GT_Utility.formatNumbers(this.getBaseMetaTileEntity().getOutputVoltage())
-                                                + String.valueOf(ConfigHandler.energyPerCell).substring(1)
-                                        : Integer.toString(0)))
+                        new FakeSyncWidget.LongSyncer(
+                                () -> this.getBaseMetaTileEntity().getStoredEU(),
+                                val -> clientEU = val))
+                .widget(
+                        new TextWidget().setStringSupplier(() -> "MAX: " + numberFormat.format(clientMaxEU))
                                 .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
                 .widget(
-                        TextWidget
-                                .dynamicString(
-                                        () -> "MAX EU/t IN: " + GT_Utility
-                                                .formatNumbers(this.getBaseMetaTileEntity().getInputVoltage()))
+                        new FakeSyncWidget.LongSyncer(
+                                () -> this.getBaseMetaTileEntity().isActive()
+                                        ? this.getBaseMetaTileEntity().getOutputVoltage() * ConfigHandler.energyPerCell
+                                        : 0,
+                                val -> clientMaxEU = val))
+                .widget(
+                        new TextWidget().setStringSupplier(() -> "MAX EU/t IN: " + numberFormat.format(clientMaxIn))
                                 .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
                 .widget(
-                        TextWidget
-                                .dynamicString(
-                                        () -> "EU/t OUT: " + GT_Utility
-                                                .formatNumbers(this.getBaseMetaTileEntity().getOutputVoltage()))
-                                .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
+                        new FakeSyncWidget.LongSyncer(
+                                () -> this.getBaseMetaTileEntity().getInputVoltage(),
+                                val -> clientMaxIn = val))
                 .widget(
-                        TextWidget
-                                .dynamicString(
-                                        () -> "AMP/t IN/OUT: " + GT_Utility
-                                                .formatNumbers(this.getBaseMetaTileEntity().getInputAmperage()))
-                                .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
+                    new TextWidget().setStringSupplier(() -> "EU/t OUT: " + numberFormat.format(clientMaxOut))
+                        .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
+                .widget(
+                    new FakeSyncWidget.LongSyncer(
+                        () -> this.getBaseMetaTileEntity().getOutputVoltage(),
+                        val -> clientMaxOut = val))
+                .widget(
+                    new TextWidget().setStringSupplier(() -> "AMP/t IN/OUT: " + numberFormat.format(clientAmps))
+                        .setDefaultColor(this.COLOR_TEXT_WHITE.get()))
+                .widget(
+                    new FakeSyncWidget.LongSyncer(
+                        () -> this.getBaseMetaTileEntity().getInputAmperage(),
+                        val -> clientAmps = val))
                 .widget(
                         new TextWidget(Text.localised("tooltip.LESU.0.name")).setDefaultColor(Color.YELLOW.getRGB())
                                 .setEnabled(widget -> this.maxEUStore() >= Long.MAX_VALUE - 1))

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_RadioHatch.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/tiered/GT_MetaTileEntity_RadioHatch.java
@@ -45,7 +45,7 @@ import com.gtnewhorizons.modularui.common.widget.FakeSyncWidget;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar;
 import com.gtnewhorizons.modularui.common.widget.ProgressBar.Direction;
 import com.gtnewhorizons.modularui.common.widget.TextWidget;
-import com.gtnewhorizons.modularui.common.widget.textfield.TextFieldWidget;
+import com.gtnewhorizons.modularui.common.widget.textfield.NumericWidget;
 
 import gregtech.api.enums.Materials;
 import gregtech.api.enums.Textures;
@@ -402,14 +402,16 @@ public class GT_MetaTileEntity_RadioHatch extends GT_MetaTileEntity_Hatch
                         new DrawableWidget().setBackground(BW_UITextures.PICTURE_DECAY_TIME_CONTAINER).setPos(120, 14)
                                 .setSize(24, 56))
                 .widget(
-                        TextWidget.dynamicString(
+                        new TextWidget().setStringSupplier(
                                 () -> StatCollector.translateToLocalFormatted("BW.NEI.display.radhatch.1", this.mass))
                                 .setTextAlignment(Alignment.Center).setPos(65, 62))
+                .widget(new FakeSyncWidget.ByteSyncer(() -> this.mass, val -> this.mass = val))
                 .widget(
-                        TextWidget.dynamicString(
+                        new TextWidget().setStringSupplier(
                                 () -> StatCollector
                                         .translateToLocalFormatted("BW.NEI.display.radhatch.0", this.getSievert()))
                                 .setTextAlignment(Alignment.Center).setPos(60, 72))
+                .widget(new FakeSyncWidget.IntegerSyncer(() -> this.sievert, val -> this.sievert = val))
                 .widget(new ButtonWidget().setOnClick((clickData, widget) -> {
                     if (!widget.isClient()) {
                         widget.getContext().openSyncedWindow(RADIATION_SHUTTER_WINDOW_ID);
@@ -442,9 +444,8 @@ public class GT_MetaTileEntity_RadioHatch extends GT_MetaTileEntity_Hatch
                                         (widget, val) -> widget.setPos(16, 29 + this.coverage / 2)
                                                 .setSize(51, 50 - this.coverage / 2)))
                 .widget(
-                        new TextFieldWidget().setSetterInt(val -> this.coverage = val.byteValue())
-                                .setGetterInt(() -> (int) this.coverage).setNumbers(0, 100)
-                                .setTextColor(Color.WHITE.dark(1)).setOnScrollNumbers(1, 5, 50)
+                        new NumericWidget().setSetter(val -> this.coverage = (byte) val).setGetter(() -> this.coverage)
+                                .setBounds(0, 100).setScrollValues(1, 5, 50).setTextColor(Color.WHITE.dark(1))
                                 .setTextAlignment(Alignment.CenterLeft)
                                 .setBackground(GT_UITextures.BACKGROUND_TEXT_FIELD.withOffset(-1, -1, 2, 2))
                                 .setPos(86, 27).setSize(30, 12))


### PR DESCRIPTION
* Replaces text fields where the user is expected to input a number with NumericWidget, supporting extended syntax and formatting. (See https://github.com/GTNewHorizons/ModularUI/pull/62.)
* Replaces instances where a dynamic text field is being communicated between server and client with a purely client-side method. In some cases this allows the client to do localization on these texts correctly. (See https://github.com/GTNewHorizons/ModularUI/pull/69.)
* Modifies other instances where the UI displays a number to use a locale-aware formatter. (See https://github.com/GTNewHorizons/ModularUI/pull/67.)

&nbsp;

Notes:
* The LESU needed some extra syncing work because a majority of its logic only runs on the server. The implementation is mildly hacky, but due to how (not) used this multiblock is, I don't think it will be a problem.
* Tracking down every single instance where a mod writes a number is nearly impossible. I use a few heuristics and code searches, but it is very likely that I miss some places. If an UI displays an unformatted or wrongly formatted number somewhere, please report it to be fixed.
