### PR TITLE
Fix multiblock structure check bugs related to borosilicate glass.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,18 +1,18 @@
 // Add your dependencies here
 
 dependencies {
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.5.24-GTNH:dev')
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.7.1:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.5.25-GTNH:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.7.2:dev')
 
-    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha34:api') { transitive = false }
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.95:dev')
-    api("com.github.GTNewHorizons:TecTech:5.3.34:dev")
+    compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha36a:api') { transitive = false }
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.45.144:dev')
+    api("com.github.GTNewHorizons:TecTech:5.3.45:dev")
     api("com.github.GTNewHorizons:GalacticGregGT5:1.1.0:dev") {
         exclude group:"com.github.GTNewHorizons", module:"bartworks"
     }
     api("com.github.GTNewHorizons:Avaritia:1.49:dev")
-    implementation("com.github.GTNewHorizons:TinkersConstruct:1.11.12-GTNH:dev")
+    implementation("com.github.GTNewHorizons:TinkersConstruct:1.11.14-GTNH:dev")
 
         compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.25:deobf") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:OpenComputers:1.10.7-GTNH:api") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:OpenComputers:1.10.9-GTNH:api") {transitive = false}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -117,7 +117,7 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.16'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.21'
 }
 
 

--- a/src/main/java/com/github/bartimaeusnek/bartworks/API/BorosilicateGlass.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/API/BorosilicateGlass.java
@@ -103,8 +103,8 @@ public class BorosilicateGlass {
         return representatives;
     }
 
-    private static byte checkWithinBound(byte val, byte lo, byte hi) {
-        return val > hi || val < lo ? -1 : val;
+    private static Byte checkWithinBound(byte val, byte lo, byte hi) {
+        return val > hi || val < lo ? null : val;
     }
 
     /**

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -365,7 +365,8 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_TileEntity_MegaMultiBlock
             return false;
 
         if (this.glassTier < 8) {
-            for (GT_MetaTileEntity_Hatch hatch : this.mExoticEnergyHatches) {
+            for (int i = 0; i < this.mExoticEnergyHatches.size(); ++i) {
+                GT_MetaTileEntity_Hatch hatch = this.mExoticEnergyHatches.get(i);
                 if (hatch.getConnectionType() == GT_MetaTileEntity_Hatch.ConnectionType.LASER) {
                     return false;
                 }
@@ -373,8 +374,8 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_TileEntity_MegaMultiBlock
                     return false;
                 }
             }
-            for (GT_MetaTileEntity_Hatch hatch : this.mEnergyHatches) {
-                if (this.glassTier < hatch.mTier) {
+            for (int i = 0; i < this.mEnergyHatches.size(); ++i) {
+                if (this.glassTier < this.mEnergyHatches.get(i).mTier) {
                     return false;
                 }
             }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaBlastFurnace.java
@@ -373,6 +373,11 @@ public class GT_TileEntity_MegaBlastFurnace extends GT_TileEntity_MegaMultiBlock
                     return false;
                 }
             }
+            for (GT_MetaTileEntity_Hatch hatch : this.mEnergyHatches) {
+                if (this.glassTier < hatch.mTier) {
+                    return false;
+                }
+            }
         }
 
         this.mHeatingCapacity = (int) this.getCoilLevel().getHeat() + 100 * (BW_Util.getTier(this.getMaxInputEu()) - 2);

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
@@ -162,7 +162,8 @@ public class GT_TileEntity_MegaChemicalReactor
         if (!this.checkPiece(STRUCTURE_PIECE_MAIN, 2, 2, 0) || this.mMaintenanceHatches.size() != 1) return false;
 
         if (this.glassTier < 8) {
-            for (GT_MetaTileEntity_Hatch hatch : this.mExoticEnergyHatches) {
+            for (int i = 0; i < this.mExoticEnergyHatches.size(); ++i) {
+                GT_MetaTileEntity_Hatch hatch = this.mExoticEnergyHatches.get(i);
                 if (hatch.getConnectionType() == GT_MetaTileEntity_Hatch.ConnectionType.LASER) {
                     return false;
                 }
@@ -170,8 +171,8 @@ public class GT_TileEntity_MegaChemicalReactor
                     return false;
                 }
             }
-            for (GT_MetaTileEntity_Hatch hatch : this.mEnergyHatches) {
-                if (this.glassTier < hatch.mTier) {
+            for (int i = 0; i < this.mEnergyHatches.size(); ++i) {
+                if (this.glassTier < this.mEnergyHatches.get(i).mTier) {
                     return false;
                 }
             }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
@@ -170,6 +170,11 @@ public class GT_TileEntity_MegaChemicalReactor
                     return false;
                 }
             }
+            for (GT_MetaTileEntity_Hatch hatch : this.mEnergyHatches) {
+                if (this.glassTier < hatch.mTier) {
+                    return false;
+                }
+            }
         }
 
         return true;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaOilCracker.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaOilCracker.java
@@ -238,7 +238,8 @@ public class GT_TileEntity_MegaOilCracker extends GT_TileEntity_MegaMultiBlockBa
         if (!this.checkPiece(STRUCTURE_PIECE_MAIN, 6, 6, 0) || this.mMaintenanceHatches.size() != 1) return false;
 
         if (this.glassTier < 8) {
-            for (GT_MetaTileEntity_Hatch hatch : this.mExoticEnergyHatches) {
+            for (int i = 0; i < this.mExoticEnergyHatches.size(); ++i) {
+                GT_MetaTileEntity_Hatch hatch = this.mExoticEnergyHatches.get(i);
                 if (hatch.getConnectionType() == GT_MetaTileEntity_Hatch.ConnectionType.LASER) {
                     return false;
                 }
@@ -246,8 +247,8 @@ public class GT_TileEntity_MegaOilCracker extends GT_TileEntity_MegaMultiBlockBa
                     return false;
                 }
             }
-            for (GT_MetaTileEntity_Hatch hatch : this.mEnergyHatches) {
-                if (this.glassTier < hatch.mTier) {
+            for (int i = 0; i < this.mEnergyHatches.size(); ++i) {
+                if (this.glassTier < this.mEnergyHatches.get(i).mTier) {
                     return false;
                 }
             }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaOilCracker.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaOilCracker.java
@@ -246,6 +246,11 @@ public class GT_TileEntity_MegaOilCracker extends GT_TileEntity_MegaMultiBlockBa
                     return false;
                 }
             }
+            for (GT_MetaTileEntity_Hatch hatch : this.mEnergyHatches) {
+                if (this.glassTier < hatch.mTier) {
+                    return false;
+                }
+            }
         }
 
         return true;


### PR DESCRIPTION
This PR aims to fix two interrelated bugs in structure checks:

---

First, tier of glass calculated by `BorosilicateGlass.ofBoroGlass` was in some cases calculated wrong. Specifically, the `getTier` method used to return tier -1 for any block which was not a valid glass. In cases where *none* of the blocks which were supposed to be glass were valid blocks, this value would propagate through the entire structure check, and end up with a "correctly" formed multiblock which thinks it has glass of tier -1.

In practice this means that you can replace pieces of the structure which should have been glass with [any block whatsoever](https://i.imgur.com/8zOYKnd.png), and if the check never finds any valid borosilicate glass, it will pass successfully.

---

The second issue concerns specifically the Mega Chemical Reactor, Mega Electric Blast Furnace, and Mega Oil Cracker. These three multiblocks use the tier of glass to limit the tier of energy hatches. However, this check previously only checked "exotic" energy hatches (lasers, multiamp, etc.) Regular energy hatches were ignored. This means that you could build, for example, an MCR with HV glass, and use an IV energy hatch on it.

I don't know whether this is actually intended; to me it seems like a bug, especially since no documentation (tooltips, QB) makes any mention of it. But it seems to have been the case since at least July of last year (https://github.com/GTNewHorizons/bartworks/commit/d17d3b8ebcaf7eccd7b8f3036f5161bf190690d6).

---

How are these two problems connected? Well, a multiblock could form without valid borosilicate glass blocks, and report its glass tier as -1. At the same time, as long as you use a regular energy hatch, the glass tier did not limit the tier of the energy hatch. This means that the multiblock could not only form, but also run, with a completely nonsensical construction: see https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15942. (The TNT EBF I linked a picture of above was also functional.)

---

This PR fixes both problems: structure check now fails instantly if an invalid block is detected, and the tier of all energy hatches is limited by the glass type used. Tested in 2.6.0-beta-2, including with alternate types of glass (alfglass).