### PR TITLE
Fix plat exploits

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/GT_Enhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/GT_Enhancement/PlatinumSludgeOverHaul.java
@@ -940,10 +940,10 @@ public class PlatinumSludgeOverHaul {
             } catch (ClassNotFoundException e) {
                 e.printStackTrace();
             }
-            if (stack.getItem() == GT_ModHandler.getModItem(GTPlusPlus.ID, "itemDustHeLiCoPtEr>", 1L).getItem()) {
+            if (stack.getItem() == GT_ModHandler.getModItem(GTPlusPlus.ID, "itemDustHeLiCoPtEr", 1L).getItem()) {
                 return true;
             }
-            if (stack.getItem() == GT_ModHandler.getModItem(GTPlusPlus.ID, "itemDustWhiteMetal>", 1L).getItem()) {
+            if (stack.getItem() == GT_ModHandler.getModItem(GTPlusPlus.ID, "itemDustWhiteMetal", 1L).getItem()) {
                 return true;
             }
         }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/material/GT_Enhancement/PlatinumSludgeOverHaul.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/material/GT_Enhancement/PlatinumSludgeOverHaul.java
@@ -940,6 +940,12 @@ public class PlatinumSludgeOverHaul {
             } catch (ClassNotFoundException e) {
                 e.printStackTrace();
             }
+            if (stack.getItem() == GT_ModHandler.getModItem(GTPlusPlus.ID, "itemDustHeLiCoPtEr>", 1L).getItem()) {
+                return true;
+            }
+            if (stack.getItem() == GT_ModHandler.getModItem(GTPlusPlus.ID, "itemDustWhiteMetal>", 1L).getItem()) {
+                return true;
+            }
         }
         if (GalaxySpace.isModLoaded()) {
             if (stack.getItem() == GT_ModHandler.getModItem(GalaxySpace.ID, "metalsblock", 1L, 7).getItem()) {


### PR DESCRIPTION
fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/6002

White metal and helicopter need the same blacklisting as other alloys like EnderiumBase or HSSS to not result in unwanted (positive) loops.

tested in full pack and works:
![image](https://github.com/GTNewHorizons/bartworks/assets/40274384/84be15b3-7307-470a-bd28-e3dc871c0a8b)
![image](https://github.com/GTNewHorizons/bartworks/assets/40274384/04d137f5-5f91-4948-a77a-108477c2f553)
