### PR TITLE
Enable input bus separation for the MCR.

### DIFF
--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
@@ -122,6 +122,14 @@ public class GT_TileEntity_MegaChemicalReactor
     }
 
     @Override
+    public void onScrewdriverRightClick(ForgeDirection side, EntityPlayer aPlayer, float aX, float aY, float aZ) {
+        inputSeparation = !inputSeparation;
+        GT_Utility.sendChatToPlayer(
+                aPlayer,
+                StatCollector.translateToLocal("GT5U.machines.separatebus") + " " + inputSeparation);
+    }
+
+    @Override
     public boolean onWireCutterRightClick(ForgeDirection side, ForgeDirection wrenchingSide, EntityPlayer aPlayer,
             float aX, float aY, float aZ) {
         if (aPlayer.isSneaking()) {

--- a/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/common/tileentities/multis/mega/GT_TileEntity_MegaChemicalReactor.java
@@ -233,4 +233,9 @@ public class GT_TileEntity_MegaChemicalReactor
     public boolean supportsVoidProtection() {
         return true;
     }
+
+    @Override
+    public boolean supportsInputSeparation() {
+        return true;
+    }
 }


### PR DESCRIPTION
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/15316.

I am honestly conflicted about enabling this for the LCR as well. Separation like this makes some automation setups significantly easier, and others possible to do in a single LCR. I am fine with effectively gating this solution to LuV, but I am not sure whether allowing it for the LCR would make certain interesting setups completely obsolete.