### PR TITLE
Void Miner logic rework

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -4,8 +4,8 @@ dependencies {
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:NotEnoughItems:2.6.0-GTNH:dev')
     runtimeOnlyNonPublishable('com.github.GTNewHorizons:waila:1.7.3:dev')
 
-    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.46.13:dev')
     compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-alpha50:api') { transitive = false }
+    api('com.github.GTNewHorizons:GT5-Unofficial:5.09.46.16:dev')
     api("com.github.GTNewHorizons:TecTech:5.4.0:dev")
     api("com.github.GTNewHorizons:GalacticGregGT5:1.1.0:dev") {
         exclude group:"com.github.GTNewHorizons", module:"bartworks"

--- a/src/main/java/com/github/bartimaeusnek/bartworks/API/VoidMinerDropAdder.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/API/VoidMinerDropAdder.java
@@ -13,27 +13,13 @@
 
 package com.github.bartimaeusnek.bartworks.API;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import com.github.bartimaeusnek.crossmod.galacticgreg.VoidMinerUtility;
 
 import gregtech.api.interfaces.ISubTagContainer;
 
 public class VoidMinerDropAdder {
 
-    private static Method getExtraDropsDimMap;
-
-    static {
-        try {
-            getExtraDropsDimMap = Class
-                    .forName("com.github.bartimaeusnek.crossmod.galacticgreg.GT_TileEntity_VoidMiner_Base")
-                    .getMethod("addMatierialToDimensionList", int.class, ISubTagContainer.class, float.class);
-        } catch (NoSuchMethodException | ClassNotFoundException e) {
-            e.printStackTrace();
-        }
-    }
-
-    public static void addDropsToDim(int dimID, ISubTagContainer material, float chance)
-            throws InvocationTargetException, IllegalAccessException {
-        getExtraDropsDimMap.invoke(null, dimID, material, chance);
+    public static void addDropsToDim(int dimID, ISubTagContainer material, float chance) {
+        VoidMinerUtility.addMaterialToDimensionList(dimID, material, chance);
     }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/MainMod.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/MainMod.java
@@ -62,6 +62,7 @@ import com.github.bartimaeusnek.bartworks.system.material.processingLoaders.Down
 import com.github.bartimaeusnek.bartworks.system.oredict.OreDictHandler;
 import com.github.bartimaeusnek.bartworks.util.ResultWrongSievert;
 import com.github.bartimaeusnek.bartworks.util.log.DebugLog;
+import com.github.bartimaeusnek.crossmod.galacticgreg.VoidMinerUtility;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
@@ -200,6 +201,7 @@ public final class MainMod {
 
         runOnServerStarted();
         StaticRecipeChangeLoaders.unificationRecipeEnforcer();
+        VoidMinerUtility.generateDropMaps();
     }
 
     private static boolean recipesAdded;

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WorldGenRoss128b.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WorldGenRoss128b.java
@@ -212,4 +212,9 @@ public class BW_WorldGenRoss128b extends BW_OreLayer {
     public boolean isGenerationAllowed(World aWorld, int aDimensionType, int aAllowedDimensionType) {
         return aDimensionType == ConfigHandler.ross128BID;
     }
+
+    @Override
+    public boolean isGenerationAllowed(String aDimName, int aDimensionType, int aAllowedDimensionType) {
+        return aDimensionType == ConfigHandler.ross128BID;
+    }
 }

--- a/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WorldGenRoss128ba.java
+++ b/src/main/java/com/github/bartimaeusnek/bartworks/system/oregen/BW_WorldGenRoss128ba.java
@@ -204,4 +204,9 @@ public class BW_WorldGenRoss128ba extends BW_OreLayer {
     public boolean isGenerationAllowed(World aWorld, int aDimensionType, int aAllowedDimensionType) {
         return aDimensionType == ConfigHandler.ross128BAID;
     }
+
+    @Override
+    public boolean isGenerationAllowed(String aDimName, int aDimensionType, int aAllowedDimensionType) {
+        return aDimensionType == ConfigHandler.ross128BAID;
+    }
 }

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
@@ -13,7 +13,6 @@
 
 package com.github.bartimaeusnek.crossmod.galacticgreg;
 
-import static bloodasp.galacticgreg.registry.GalacticGregRegistry.getModContainers;
 import static com.github.bartimaeusnek.bartworks.util.BW_Tooltip_Reference.MULTIBLOCK_ADDED_BY_BARTIMAEUSNEK_VIA_BARTWORKS;
 import static gregtech.api.enums.GT_HatchElement.Energy;
 import static gregtech.api.enums.GT_HatchElement.InputBus;
@@ -22,59 +21,32 @@ import static gregtech.api.enums.GT_HatchElement.Maintenance;
 import static gregtech.api.enums.GT_HatchElement.OutputBus;
 import static gregtech.api.enums.GT_Values.VN;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraft.world.World;
 import net.minecraft.world.gen.ChunkProviderServer;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.FluidStack;
 
-import com.github.bartimaeusnek.bartworks.common.configs.ConfigHandler;
-import com.github.bartimaeusnek.bartworks.system.material.Werkstoff;
-import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
-import com.github.bartimaeusnek.bartworks.system.oregen.BW_OreLayer;
-import com.github.bartimaeusnek.bartworks.util.Pair;
-import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 
-import bloodasp.galacticgreg.GT_Worldgen_GT_Ore_Layer_Space;
-import bloodasp.galacticgreg.GT_Worldgen_GT_Ore_SmallPieces_Space;
-import bloodasp.galacticgreg.GalacticGreg;
-import bloodasp.galacticgreg.api.ModDimensionDef;
-import bloodasp.galacticgreg.bartworks.BW_Worldgen_Ore_Layer_Space;
-import bloodasp.galacticgreg.bartworks.BW_Worldgen_Ore_SmallOre_Space;
-import cpw.mods.fml.common.registry.GameRegistry;
-import gregtech.api.GregTech_API;
 import gregtech.api.enums.GT_Values;
-import gregtech.api.enums.Materials;
 import gregtech.api.interfaces.IHatchElement;
-import gregtech.api.interfaces.ISubTagContainer;
 import gregtech.api.objects.XSTR;
 import gregtech.api.util.GT_Multiblock_Tooltip_Builder;
 import gregtech.api.util.GT_Utility;
-import gregtech.common.GT_Worldgen_GT_Ore_Layer;
-import gregtech.common.GT_Worldgen_GT_Ore_SmallPieces;
+import gregtech.api.util.shutdown.ShutDownReasonRegistry;
 import gregtech.common.tileentities.machines.multi.GT_MetaTileEntity_DrillerBase;
 
 public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_DrillerBase {
 
-    private static final ArrayListMultimap<Integer, Pair<Pair<Integer, Block>, Float>> extraDropsDimMap = ArrayListMultimap
-            .create();
-    private static final FluidStack[] NOBLE_GASSES = { WerkstoffLoader.Neon.getFluidOrGas(1),
-            WerkstoffLoader.Krypton.getFluidOrGas(1), WerkstoffLoader.Xenon.getFluidOrGas(1),
-            WerkstoffLoader.Oganesson.getFluidOrGas(1) };
-
-    private Map<Pair<Integer, Block>, Float> dropmap = null;
+    private VoidMinerUtility.DropMap dropMap = null;
     private float totalWeight;
     private int multiplier = 1;
 
@@ -83,30 +55,13 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
     private boolean mBlacklist = false;
 
     /**
-     * Public method giving other mods the ability to add manually a material with an ore version into the external
-     * dropmap for a specified dim id
-     *
-     * @param DimensionID the dim id targeted
-     * @param Material    the material with an ore version
-     * @param weight      the non normalised version of the given weight
+     * @Deprecated Use {@link VoidMinerUtility#addBlockToDimensionList}
      */
-    public static void addMatierialToDimensionList(int DimensionID, ISubTagContainer Material, float weight) {
-        if (Material instanceof Materials gtMaterial) {
-            addBlockToDimensionList(DimensionID, GregTech_API.sBlockOres1, gtMaterial.mMetaItemSubID, weight);
-        } else if (Material instanceof Werkstoff werkstoff) {
-            addBlockToDimensionList(DimensionID, WerkstoffLoader.BWOres, werkstoff.getmID(), weight);
-        }
-    }
-
+    @Deprecated
     public static void addBlockToDimensionList(int dimId, Block block, int meta, float weight) {
-        getExtraDropsDimMap().put(dimId, new Pair<>(new Pair<>(meta, block), weight));
+        VoidMinerUtility.addBlockToDimensionList(dimId, block, meta, weight);
     }
 
-    // adding tellurium to OW to ensure a way to get it, as it's used in Magneto Resonatic Dust and Circuit Compound MK3
-    // Dust
-    static {
-        addMatierialToDimensionList(0, Materials.Tellurium, 8.0f);
-    }
 
     public GT_TileEntity_VoidMiner_Base(int aID, String aName, String aNameRegional, int tier) {
         super(aID, aName, aNameRegional);
@@ -159,16 +114,17 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
     @Override
     protected boolean workingAtBottom(ItemStack aStack, int xDrill, int yDrill, int zDrill, int xPipe, int zPipe,
             int yHead, int oldYHead) {
-        // if the dropmap has never been initialised or if the dropmap is empty
-        if (this.dropmap == null || this.totalWeight == 0) this.calculateDropMap();
+        // if the dropMap has never been initialised or if the dropMap is empty
+        if (this.dropMap == null || this.totalWeight == 0) this.calculateDropMap();
 
         if (this.totalWeight != 0.f) {
             this.handleFluidConsumption();
             this.handleOutputs();
             return true;
+        } else {
+            this.stopMachine(ShutDownReasonRegistry.NONE);
+            return false;
         }
-        this.stopMachine();
-        return false;
     }
 
     @Override
@@ -205,154 +161,17 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
     }
 
     /**
-     * getter for the external drop map
+     * method used to pick the next ore in the dropMap.
      *
-     * @return the extraDropsDimMap
+     * @return the chosen ore
      */
-    public static ArrayListMultimap<Integer, Pair<Pair<Integer, Block>, Float>> getExtraDropsDimMap() {
-        return extraDropsDimMap;
-    }
-
-    /**
-     * Makes a predicate for the GT normal ore veins worldgen
-     *
-     * @return the predicate
-     */
-    private Predicate<GT_Worldgen_GT_Ore_Layer> makeOreLayerPredicate() {
-        World world = this.getBaseMetaTileEntity().getWorld();
-        return switch (world.provider.dimensionId) {
-            case -1 -> gt_worldgen -> gt_worldgen.mNether;
-            case 0 -> gt_worldgen -> gt_worldgen.mOverworld;
-            case 1 -> gt_worldgen -> gt_worldgen.mEnd || gt_worldgen.mEndAsteroid;
-            /*
-             * explicitly giving different dim numbers so it default to false in the config, keeping compat with the
-             * current worldgen config
-             */
-            case 7 -> gt_worldgen -> gt_worldgen.isGenerationAllowed(world, 0, 7);
-            default -> throw new IllegalStateException();
-        };
-    }
-
-    /**
-     * Makes a predicate for the GT normal small ore worldgen
-     *
-     * @return the predicate
-     */
-    private Predicate<GT_Worldgen_GT_Ore_SmallPieces> makeSmallOresPredicate() {
-        World world = this.getBaseMetaTileEntity().getWorld();
-        return switch (world.provider.dimensionId) {
-            case -1 -> gt_worldgen -> gt_worldgen.mNether;
-            case 0 -> gt_worldgen -> gt_worldgen.mOverworld;
-            case 1 -> gt_worldgen -> gt_worldgen.mEnd;
-            /*
-             * explicitly giving different dim numbers so it default to false in the config, keeping compat with the
-             * current worldgen config
-             */
-            case 7 -> gt_worldgen -> gt_worldgen.isGenerationAllowed(world, 0, 7);
-            default -> throw new IllegalStateException();
-        };
-    }
-
-    /**
-     * Method used to add an ore to the droplist
-     *
-     * @param key   a Pair of <int, bool> where the int is the meta of the ore, and the bool is true for BW ores, false
-     *              for GT ores
-     * @param value the non normalised weight
-     */
-    private void addDrop(Pair<Integer, Boolean> key, float value) {
-        if (key.getValue()) {
-            addDrop(WerkstoffLoader.BWOres, key.getKey(), value);
-        } else {
-            addDrop(GregTech_API.sBlockOres1, key.getKey(), value);
-        }
-    }
-
-    private void addDrop(Block block, int meta, float value) {
-        Pair<Integer, Block> key = new Pair<>(meta, block);
-        final ItemStack ore = this.getOreItemStack(key);
-        if (ConfigHandler.voidMinerBlacklist.contains(
-                String.format(
-                        "%s:%d",
-                        GameRegistry.findUniqueIdentifierFor(ore.getItem()).toString(),
-                        ore.getItemDamage())))
-            return;
-        if (!this.dropmap.containsKey(key)) this.dropmap.put(key, value);
-        else this.dropmap.put(key, this.dropmap.get(key) + value);
-    }
-
-    /**
-     * Method to add the ores of a vanilla GT worldgen
-     *
-     * @param oreLayerPredicate the predicate made by makeOreLayerPredicate
-     */
-    private void getDropsVanillaVeins(Predicate<GT_Worldgen_GT_Ore_Layer> oreLayerPredicate) {
-        GT_Worldgen_GT_Ore_Layer.sList.stream()
-                .filter(gt_worldgen -> gt_worldgen.mEnabled && oreLayerPredicate.test(gt_worldgen)).forEach(element -> {
-                    this.addDrop(new Pair<>((int) element.mPrimaryMeta, false), element.mWeight);
-                    this.addDrop(new Pair<>((int) element.mSecondaryMeta, false), element.mWeight);
-                    this.addDrop(new Pair<>((int) element.mSporadicMeta, false), element.mWeight / 8f);
-                    this.addDrop(new Pair<>((int) element.mBetweenMeta, false), element.mWeight / 8f);
-                });
-    }
-
-    /**
-     * Method to add the small ores of a vanilla GT worldgen
-     *
-     * @param smallOresPredicate the predicate made by makeSmallOresPredicate
-     */
-    private void getDropsVanillaSmallOres(Predicate<GT_Worldgen_GT_Ore_SmallPieces> smallOresPredicate) {
-        GT_Worldgen_GT_Ore_SmallPieces.sList.stream()
-                .filter(gt_worldgen -> gt_worldgen.mEnabled && smallOresPredicate.test(gt_worldgen))
-                .forEach(element -> this.addDrop(new Pair<>((int) element.mMeta, false), element.mAmount));
-    }
-
-    /**
-     * add to the dropmap the ores from the gagreg space worldgen corresponding to the target dim
-     *
-     * @param finalDef ModDimensionDef corresponding to the target dim
-     */
-    private void getDropsOreVeinsSpace(ModDimensionDef finalDef) {
-        GalacticGreg.oreVeinWorldgenList.stream()
-                .filter(
-                        gt_worldgen -> gt_worldgen.mEnabled
-                                && gt_worldgen instanceof GT_Worldgen_GT_Ore_Layer_Space oreLayerSpace
-                                && oreLayerSpace.isEnabledForDim(finalDef))
-                .map(gt_worldgen -> (GT_Worldgen_GT_Ore_Layer_Space) gt_worldgen).forEach(element -> {
-                    this.addDrop(new Pair<>((int) element.mPrimaryMeta, false), element.mWeight);
-                    this.addDrop(new Pair<>((int) element.mSecondaryMeta, false), element.mWeight);
-                    this.addDrop(new Pair<>((int) element.mSporadicMeta, false), element.mWeight / 8f);
-                    this.addDrop(new Pair<>((int) element.mBetweenMeta, false), element.mWeight / 8f);
-                });
-    }
-
-    /**
-     * add to the dropmap the small ores from the gagreg space worldgen corresponding to the target dim
-     *
-     * @param finalDef ModDimensionDef corresponding to the target dim
-     */
-    private void getDropsSmallOreSpace(ModDimensionDef finalDef) {
-        GalacticGreg.smallOreWorldgenList.stream()
-                .filter(
-                        gt_worldgen -> gt_worldgen.mEnabled
-                                && gt_worldgen instanceof GT_Worldgen_GT_Ore_SmallPieces_Space oreSmallPiecesSpace
-                                && oreSmallPiecesSpace.isEnabledForDim(finalDef))
-                .map(gt_worldgen -> (GT_Worldgen_GT_Ore_SmallPieces_Space) gt_worldgen)
-                .forEach(element -> this.addDrop(new Pair<>((int) element.mMeta, false), element.mAmount));
-    }
-
-    /**
-     * method used to pick the next key in the dropmap that will be used to generate the ore.
-     *
-     * @return the chosen key
-     */
-    private Pair<Integer, Block> getOreDamage() {
-        float curentWeight = 0.f;
+    private ItemStack nextOre() {
+        float currentWeight = 0.f;
         while (true) {
-            float randomnumber = XSTR.XSTR_INSTANCE.nextFloat() * this.totalWeight;
-            for (Map.Entry<Pair<Integer, Block>, Float> entry : this.dropmap.entrySet()) {
-                curentWeight += entry.getValue();
-                if (randomnumber < curentWeight) return entry.getKey();
+            float randomNumber = XSTR.XSTR_INSTANCE.nextFloat() * this.totalWeight;
+            for (Map.Entry<GT_Utility.ItemId, Float> entry : this.dropMap.getInternalMap().entrySet()) {
+                currentWeight += entry.getValue();
+                if (randomNumber < currentWeight) return entry.getKey().getItemStack();
             }
         }
     }
@@ -364,10 +183,10 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
      */
     private FluidStack getNobleGasInputAndSetMultiplier() {
         for (FluidStack s : this.getStoredFluids()) {
-            for (int i = 0; i < NOBLE_GASSES.length; i++) {
-                FluidStack ng = NOBLE_GASSES[i];
+            for (int i = 0; i < VoidMinerUtility.NOBLE_GASSES.length; i++) {
+                FluidStack ng = VoidMinerUtility.NOBLE_GASSES[i];
                 if (ng.isFluidEqual(s)) {
-                    this.multiplier = this.TIER_MULTIPLIER * (2 << (i == NOBLE_GASSES.length - 1 ? i + 2 : i + 1));
+                    this.multiplier = this.TIER_MULTIPLIER * VoidMinerUtility.NOBEL_GASSES_MULTIPLIER[i];
                     return s;
                 }
             }
@@ -379,7 +198,7 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
      * method used to decrement the quantity of gas in the hatch
      *
      * @param gasToConsume the fluid stack in the hatch
-     * @return if yes or no it was able to decrement the quantity of the fluidstack
+     * @return if yes or no it was able to decrement the quantity of the fluidStack
      */
     private boolean consumeNobleGas(FluidStack gasToConsume) {
         for (FluidStack s : this.getStoredFluids()) {
@@ -401,143 +220,44 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
     }
 
     /**
-     * Handles the addition of Ross dims' ores into the drop map
-     *
-     * @param aID dim id of Ross128b or Ross128ba
-     */
-    private void getDropMapRoss(int aID) {
-        Consumer<BW_OreLayer> addToList = this.makeAddToList();
-        BW_OreLayer.sList.stream()
-                .filter(
-                        gt_worldgen -> gt_worldgen.mEnabled && gt_worldgen instanceof BW_OreLayer
-                                && gt_worldgen.isGenerationAllowed(null, aID, 0))
-                .forEach(addToList);
-    }
-
-    /**
-     * Method used to generate a consumer used specifically to add BW ores into the dropmap
-     *
-     * @return the consumer
-     */
-    private Consumer<BW_OreLayer> makeAddToList() {
-        return element -> {
-            List<Pair<Integer, Boolean>> data = element.getStacksRawData();
-            for (int i = 0; i < data.size(); i++) {
-                if (i < data.size() - 2) this.addDrop(data.get(i), element.mWeight);
-                else this.addDrop(data.get(i), element.mWeight / 8f);
-            }
-        };
-    }
-
-    /**
-     * Method used to build the ModDimensionDef object corresponding to the dimension the VM is in.
-     *
-     * @return the ModDimensionDef object.
-     */
-    private ModDimensionDef makeModDimDef() {
-        return getModContainers().stream().flatMap(modContainer -> modContainer.getDimensionList().stream())
-                .filter(
-                        modDimensionDef -> modDimensionDef.getChunkProviderName().equals(
-                                ((ChunkProviderServer) this.getBaseMetaTileEntity().getWorld()
-                                        .getChunkProvider()).currentChunkProvider.getClass().getName()))
-                .findFirst().orElse(null);
-    }
-
-    /**
-     * Handles the addition of small ores for bartwork dims
-     *
-     * @param finalDef  the ModDimensionDef object corresponding to the dim
-     * @param addToList a consumer used to add the ores from the vein with proper weight
-     */
-    private void addOresVeinsBartworks(ModDimensionDef finalDef, Consumer<BW_OreLayer> addToList) {
-        try {
-            GalacticGreg.oreVeinWorldgenList.stream()
-                    .filter(
-                            gt_worldgen -> gt_worldgen.mEnabled
-                                    && gt_worldgen instanceof BW_Worldgen_Ore_Layer_Space oreLayerSpace
-                                    && oreLayerSpace.isEnabledForDim(finalDef))
-                    .map(gt_worldgen -> (BW_Worldgen_Ore_Layer_Space) gt_worldgen).forEach(addToList);
-        } catch (NullPointerException ignored) {}
-    }
-
-    /**
-     * Handles the addition of small ores for bartwork dims
-     *
-     * @param finalDef the ModDimensionDef object corresponding to the dim
-     */
-    private void addSmallOresBartworks(ModDimensionDef finalDef) {
-        try {
-            GalacticGreg.smallOreWorldgenList.stream()
-                    .filter(
-                            gt_worldgen -> gt_worldgen.mEnabled
-                                    && gt_worldgen instanceof BW_Worldgen_Ore_SmallOre_Space smallOreSpace
-                                    && smallOreSpace.isEnabledForDim(finalDef))
-                    .map(gt_worldgen -> (BW_Worldgen_Ore_SmallOre_Space) gt_worldgen).forEach(
-                            element -> this
-                                    .addDrop(new Pair<>(element.mPrimaryMeta, element.bwOres != 0), element.mDensity));
-        } catch (NullPointerException ignored) {}
-    }
-
-    /**
-     * Handles the ores added manually with addMatierialToDimensionList
+     * Handles the ores added manually with {@link VoidMinerUtility#addMaterialToDimensionList}
      *
      * @param id the specified dim id
      */
     private void handleExtraDrops(int id) {
-        Optional.ofNullable(getExtraDropsDimMap().get(id)).ifPresent(e -> e.forEach(f -> {
-            Pair<Integer, Block> key = f.getKey();
-            addDrop(key.getValue(), key.getKey(), f.getValue());
-        }));
+        Optional.ofNullable(VoidMinerUtility.extraDropsDimMap.get(id)).ifPresent(
+                extraDropMap -> extraDropMap.getInternalMap()
+                        .forEach((ItemId, weight) -> this.dropMap.addDrop(ItemId.getItemStack(), weight)));
     }
 
     /**
-     * Computes the total weight for normalisation
-     */
-    private void calculateTotalWeight() {
-        this.totalWeight = 0.0f;
-        this.dropmap.values().forEach(f -> this.totalWeight += f);
-    }
-
-    /**
-     * Computes the ores of the dim for the specifed dim id
+     * Gets the DropMap of the dim for the specified dim id
      *
      * @param id the dim number
      */
     private void handleModDimDef(int id) {
-        // vanilla dims or TF
-        if (id <= 1 && id >= -1 || id == 7) {
-            this.getDropsVanillaVeins(this.makeOreLayerPredicate());
-            this.getDropsVanillaSmallOres(this.makeSmallOresPredicate());
-
-            // ross dims
-        } else if (id == ConfigHandler.ross128BID || id == ConfigHandler.ross128BAID) {
-            this.getDropMapRoss(id);
-
-            // other space dims
+        if (VoidMinerUtility.dropMapsByDimId.containsKey(id)) {
+            this.dropMap = VoidMinerUtility.dropMapsByDimId.get(id);
         } else {
-            Optional.ofNullable(this.makeModDimDef()).ifPresent(def -> {
-                // normal space dim
-                this.getDropsOreVeinsSpace(def);
-                this.getDropsSmallOreSpace(def);
+            String chunkProviderName = ((ChunkProviderServer) this.getBaseMetaTileEntity().getWorld()
+                    .getChunkProvider()).currentChunkProvider.getClass().getName();
 
-                // BW space dim
-                Consumer<BW_OreLayer> addToList = this.makeAddToList();
-                this.addOresVeinsBartworks(def, addToList);
-                this.addSmallOresBartworks(def);
-            });
+            if (VoidMinerUtility.dropMapsByChunkProviderName.containsKey(chunkProviderName)) {
+                this.dropMap = VoidMinerUtility.dropMapsByChunkProviderName.get(chunkProviderName);
+            }
         }
     }
 
     /**
      * Computes first the ores related to the dim the VM is in, then the ores added manually, then it computes the
-     * totalweight for normalisation
+     * totalWeight for normalisation
      */
     private void calculateDropMap() {
-        this.dropmap = new HashMap<>();
+        this.dropMap = new VoidMinerUtility.DropMap();
         int id = this.getBaseMetaTileEntity().getWorld().provider.dimensionId;
         this.handleModDimDef(id);
         this.handleExtraDrops(id);
-        this.calculateTotalWeight();
+        this.totalWeight = dropMap.getTotalWeight();
     }
 
     /**
@@ -545,24 +265,14 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
      */
     private void handleOutputs() {
         final List<ItemStack> inputOres = this.getStoredInputs().stream().filter(GT_Utility::isOre)
-                .collect(Collectors.toList());
-        final ItemStack output = this.getOreItemStack(this.getOreDamage());
+                .collect(Collectors.toList());;
+        final ItemStack output = this.nextOre();
+        output.stackSize = multiplier;
         if (inputOres.size() == 0
-                || this.mBlacklist && inputOres.stream().allMatch(is -> !GT_Utility.areStacksEqual(is, output))
+                || this.mBlacklist && inputOres.stream().noneMatch(is -> GT_Utility.areStacksEqual(is, output))
                 || !this.mBlacklist && inputOres.stream().anyMatch(is -> GT_Utility.areStacksEqual(is, output)))
             this.addOutput(output);
         this.updateSlots();
-    }
-
-    /**
-     * Builds the ore item stack from the key specified in the dropmap
-     *
-     * @param stats the key of the dropmap
-     * @return an ItemStack corresponding to the target ore, with a stacksize corresponding to the multiplier induced by
-     *         the gas used
-     */
-    private ItemStack getOreItemStack(Pair<Integer, Block> stats) {
-        return new ItemStack(stats.getValue(), this.multiplier, stats.getKey());
     }
 
     @Override

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
@@ -236,13 +236,13 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
      */
     private void handleModDimDef(int id) {
         if (VoidMinerUtility.dropMapsByDimId.containsKey(id)) {
-            this.dropMap = VoidMinerUtility.dropMapsByDimId.get(id);
+            this.dropMap = VoidMinerUtility.dropMapsByDimId.get(id).copy();
         } else {
             String chunkProviderName = ((ChunkProviderServer) this.getBaseMetaTileEntity().getWorld()
                     .getChunkProvider()).currentChunkProvider.getClass().getName();
 
             if (VoidMinerUtility.dropMapsByChunkProviderName.containsKey(chunkProviderName)) {
-                this.dropMap = VoidMinerUtility.dropMapsByChunkProviderName.get(chunkProviderName);
+                this.dropMap = VoidMinerUtility.dropMapsByChunkProviderName.get(chunkProviderName).copy();
             }
         }
     }

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/GT_TileEntity_VoidMiner_Base.java
@@ -62,7 +62,6 @@ public abstract class GT_TileEntity_VoidMiner_Base extends GT_MetaTileEntity_Dri
         VoidMinerUtility.addBlockToDimensionList(dimId, block, meta, weight);
     }
 
-
     public GT_TileEntity_VoidMiner_Base(int aID, String aName, String aNameRegional, int tier) {
         super(aID, aName, aNameRegional);
         this.TIER_MULTIPLIER = (byte) Math.max(tier, 1);

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/VoidMinerUtility.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/VoidMinerUtility.java
@@ -107,6 +107,13 @@ public class VoidMinerUtility {
         public Map<GT_Utility.ItemId, Float> getInternalMap() {
             return internalMap;
         }
+
+        public DropMap copy() {
+            DropMap result = new DropMap();
+            result.internalMap.putAll(internalMap);
+            result.totalWeight = totalWeight;
+            return result;
+        }
     }
 
     public static final Map<Integer, DropMap> dropMapsByDimId = new HashMap<>();

--- a/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/VoidMinerUtility.java
+++ b/src/main/java/com/github/bartimaeusnek/crossmod/galacticgreg/VoidMinerUtility.java
@@ -1,0 +1,306 @@
+package com.github.bartimaeusnek.crossmod.galacticgreg;
+
+import static bloodasp.galacticgreg.registry.GalacticGregRegistry.getModContainers;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+import net.minecraft.block.Block;
+import net.minecraft.init.Items;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidStack;
+
+import com.github.bartimaeusnek.bartworks.common.configs.ConfigHandler;
+import com.github.bartimaeusnek.bartworks.system.material.Werkstoff;
+import com.github.bartimaeusnek.bartworks.system.material.WerkstoffLoader;
+import com.github.bartimaeusnek.bartworks.system.oregen.BW_OreLayer;
+
+import bloodasp.galacticgreg.GT_Worldgen_GT_Ore_Layer_Space;
+import bloodasp.galacticgreg.GT_Worldgen_GT_Ore_SmallPieces_Space;
+import bloodasp.galacticgreg.GalacticGreg;
+import bloodasp.galacticgreg.api.ModContainer;
+import bloodasp.galacticgreg.api.ModDimensionDef;
+import bloodasp.galacticgreg.bartworks.BW_Worldgen_Ore_Layer_Space;
+import bloodasp.galacticgreg.bartworks.BW_Worldgen_Ore_SmallOre_Space;
+import cpw.mods.fml.common.registry.GameRegistry;
+import gregtech.api.GregTech_API;
+import gregtech.api.enums.Materials;
+import gregtech.api.interfaces.ISubTagContainer;
+import gregtech.api.util.GT_Utility;
+import gregtech.common.GT_Worldgen_GT_Ore_Layer;
+import gregtech.common.GT_Worldgen_GT_Ore_SmallPieces;
+
+public class VoidMinerUtility {
+
+    public static final FluidStack[] NOBLE_GASSES = { WerkstoffLoader.Neon.getFluidOrGas(1),
+            WerkstoffLoader.Krypton.getFluidOrGas(1), WerkstoffLoader.Xenon.getFluidOrGas(1),
+            WerkstoffLoader.Oganesson.getFluidOrGas(1) };
+    public static final int[] NOBEL_GASSES_MULTIPLIER = { 4, 8, 16, 64 };
+
+    public static class DropMap {
+
+        private float totalWeight;
+        private final Map<GT_Utility.ItemId, Float> internalMap;
+
+        public DropMap() {
+            internalMap = new HashMap<>();
+            totalWeight = 0;
+        }
+
+        /**
+         * Method used to add an ore to the DropMap
+         *
+         * @param weight   the non normalised weight
+         * @param isBWOres true for BW ores, false for GT ores
+         */
+        public void addDrop(int meta, float weight, boolean isBWOres) {
+            if (isBWOres) {
+                addDrop(WerkstoffLoader.BWOres, meta, weight);
+            } else {
+                addDrop(GregTech_API.sBlockOres1, meta, weight);
+            }
+        }
+
+        /**
+         * Method used to add any item to the DropMap. Will be blocked if blacklisted.
+         *
+         * @param weight the non normalised weight
+         */
+        public void addDrop(Block block, int meta, float weight) {
+            if (ConfigHandler.voidMinerBlacklist.contains(
+                    String.format("%s:%d", GameRegistry.findUniqueIdentifierFor(block).toString(), meta)))
+                return;
+            Item item = Item.getItemFromBlock(block);
+            addDrop(item, meta, weight);
+        }
+
+        /**
+         * Method used to add any item to the DropMap. Will be blocked if blacklisted.
+         *
+         * @param weight the non normalised weight
+         */
+        public void addDrop(ItemStack itemStack, float weight) {
+            Item item = itemStack.getItem();
+            int meta = Items.feather.getDamage(itemStack);
+            if (ConfigHandler.voidMinerBlacklist.contains(
+                    String.format(
+                            "%s:%d",
+                            GameRegistry.findUniqueIdentifierFor(Block.getBlockFromItem(item)).toString(),
+                            meta)))
+                return;
+            addDrop(item, meta, weight);
+        }
+
+        private void addDrop(Item item, int meta, float weight) {
+            GT_Utility.ItemId ore = GT_Utility.ItemId.createNoCopy(item, meta, null);
+            internalMap.merge(ore, weight, Float::sum);
+            totalWeight += weight;
+        }
+
+        public float getTotalWeight() {
+            return totalWeight;
+        }
+
+        public Map<GT_Utility.ItemId, Float> getInternalMap() {
+            return internalMap;
+        }
+    }
+
+    public static final Map<Integer, DropMap> dropMapsByDimId = new HashMap<>();
+    public static final Map<String, DropMap> dropMapsByChunkProviderName = new HashMap<>();
+    public static final Map<Integer, DropMap> extraDropsDimMap = new HashMap<>();
+
+    // Adds tellurium to OW to ensure a way to get it, as it's used in Magneto Resonatic
+    // Dust and Circuit Compound MK3 Dust
+    static {
+        addMaterialToDimensionList(0, Materials.Tellurium, 8.0f);
+    }
+
+    /**
+     * Computes the ores of the dims
+     */
+    public static void generateDropMaps() {
+        // vanilla dims or TF
+        dropMapsByDimId.put(-1, getDropMapVanilla(-1));
+        dropMapsByDimId.put(0, getDropMapVanilla(0));
+        dropMapsByDimId.put(1, getDropMapVanilla(1));
+        dropMapsByDimId.put(7, getDropMapVanilla(7));
+
+        // ross dims
+        dropMapsByDimId.put(ConfigHandler.ross128BID, getDropMapRoss(ConfigHandler.ross128BID));
+        dropMapsByDimId.put(ConfigHandler.ross128BAID, getDropMapRoss(ConfigHandler.ross128BAID));
+
+        // other space dims
+        for (ModContainer modContainer : getModContainers()) {
+            for (ModDimensionDef dimDef : modContainer.getDimensionList()) {
+                dropMapsByChunkProviderName.put(dimDef.getChunkProviderName(), getDropMapSpace(dimDef));
+            }
+        }
+    }
+
+    /**
+     * Method to generate a DropMap that contains ores of a vanilla GT worldgen
+     */
+    private static DropMap getDropMapVanilla(int dimId) {
+        DropMap dropMap = new DropMap();
+
+        // Ore Veins
+        Predicate<GT_Worldgen_GT_Ore_Layer> oreLayerPredicate = makeOreLayerPredicate(dimId);
+        GT_Worldgen_GT_Ore_Layer.sList.stream()
+                .filter(gt_worldgen -> gt_worldgen.mEnabled && oreLayerPredicate.test(gt_worldgen)).forEach(element -> {
+                    dropMap.addDrop(element.mPrimaryMeta, element.mWeight, false);
+                    dropMap.addDrop(element.mSecondaryMeta, element.mWeight, false);
+                    dropMap.addDrop(element.mSporadicMeta, element.mWeight / 8f, false);
+                    dropMap.addDrop(element.mBetweenMeta, element.mWeight / 8f, false);
+                });
+
+        // Small Ores
+        Predicate<GT_Worldgen_GT_Ore_SmallPieces> smallOresPredicate = makeSmallOresPredicate(dimId);
+        GT_Worldgen_GT_Ore_SmallPieces.sList.stream()
+                .filter(gt_worldgen -> gt_worldgen.mEnabled && smallOresPredicate.test(gt_worldgen))
+                .forEach(element -> dropMap.addDrop(element.mMeta, element.mAmount, false));
+        return dropMap;
+    }
+
+    /**
+     * Makes a predicate for the GT normal ore veins worldgen
+     *
+     * @return the predicate
+     */
+    private static Predicate<GT_Worldgen_GT_Ore_Layer> makeOreLayerPredicate(int dimensionId) {
+        return switch (dimensionId) {
+            case -1 -> gt_worldgen -> gt_worldgen.mNether;
+            case 0 -> gt_worldgen -> gt_worldgen.mOverworld;
+            case 1 -> gt_worldgen -> gt_worldgen.mEnd || gt_worldgen.mEndAsteroid;
+            /*
+             * explicitly giving different dim numbers so that it default to false in the config, keeping compat with
+             * the current worldgen config
+             */
+            case 7 -> gt_worldgen -> gt_worldgen.isGenerationAllowed("Twilight Forest", 0, 7);
+            default -> throw new IllegalStateException();
+        };
+    }
+
+    /**
+     * Makes a predicate for the GT normal small ore worldgen
+     *
+     * @return the predicate
+     */
+    private static Predicate<GT_Worldgen_GT_Ore_SmallPieces> makeSmallOresPredicate(int dimensionId) {
+        return switch (dimensionId) {
+            case -1 -> gt_worldgen -> gt_worldgen.mNether;
+            case 0 -> gt_worldgen -> gt_worldgen.mOverworld;
+            case 1 -> gt_worldgen -> gt_worldgen.mEnd;
+            /*
+             * explicitly giving different dim numbers so that it default to false in the config, keeping compat with
+             * the current worldgen config
+             */
+            case 7 -> gt_worldgen -> gt_worldgen.isGenerationAllowed("Twilight Forest", 0, 7);
+            default -> throw new IllegalStateException();
+        };
+    }
+
+    /**
+     * Create a DropMap that contains ores of Ross dims
+     *
+     * @param aID dim id of Ross128b or Ross128ba
+     */
+    private static DropMap getDropMapRoss(int aID) {
+        DropMap dropMap = new DropMap();
+        for (BW_OreLayer oreLayer : BW_OreLayer.sList) {
+            if (oreLayer.mEnabled && oreLayer.isGenerationAllowed("", aID, 0)) {
+                List<ItemStack> data = oreLayer.getStacks();
+                dropMap.addDrop(data.get(0), oreLayer.mWeight);
+                dropMap.addDrop(data.get(1), oreLayer.mWeight);
+                dropMap.addDrop(data.get(2), oreLayer.mWeight / 8f);
+                dropMap.addDrop(data.get(3), oreLayer.mWeight / 8f);
+            }
+        }
+        return dropMap;
+    }
+
+    /**
+     * Create a DropMap contains the ores from the galacticGreg space worldgen corresponding to the target dim
+     *
+     * @param finalDef ModDimensionDef corresponding to the target dim
+     */
+    private static DropMap getDropMapSpace(ModDimensionDef finalDef) {
+        DropMap dropMap = new DropMap();
+
+        // Normal Ore Veins
+        GalacticGreg.oreVeinWorldgenList.stream()
+                .filter(
+                        gt_worldgen -> gt_worldgen.mEnabled
+                                && gt_worldgen instanceof GT_Worldgen_GT_Ore_Layer_Space oreLayerSpace
+                                && oreLayerSpace.isEnabledForDim(finalDef))
+                .map(gt_worldgen -> (GT_Worldgen_GT_Ore_Layer_Space) gt_worldgen).forEach(element -> {
+                    dropMap.addDrop(element.mPrimaryMeta, element.mWeight, false);
+                    dropMap.addDrop(element.mSecondaryMeta, element.mWeight, false);
+                    dropMap.addDrop(element.mSporadicMeta, element.mWeight / 8f, false);
+                    dropMap.addDrop(element.mBetweenMeta, element.mWeight / 8f, false);
+                });
+
+        // Normal Small Ores
+        GalacticGreg.smallOreWorldgenList.stream()
+                .filter(
+                        gt_worldgen -> gt_worldgen.mEnabled
+                                && gt_worldgen instanceof GT_Worldgen_GT_Ore_SmallPieces_Space oreSmallPiecesSpace
+                                && oreSmallPiecesSpace.isEnabledForDim(finalDef))
+                .map(gt_worldgen -> (GT_Worldgen_GT_Ore_SmallPieces_Space) gt_worldgen)
+                .forEach(element -> dropMap.addDrop(element.mMeta, element.mAmount, false));
+
+        // BW Ore Veins
+        try {
+            GalacticGreg.oreVeinWorldgenList.stream()
+                    .filter(
+                            gt_worldgen -> gt_worldgen.mEnabled
+                                    && gt_worldgen instanceof BW_Worldgen_Ore_Layer_Space oreLayerSpace
+                                    && oreLayerSpace.isEnabledForDim(finalDef))
+                    .map(gt_worldgen -> (BW_Worldgen_Ore_Layer_Space) gt_worldgen).forEach(oreLayer -> {
+                        List<ItemStack> data = oreLayer.getStacks();
+                        dropMap.addDrop(data.get(0), oreLayer.mWeight);
+                        dropMap.addDrop(data.get(1), oreLayer.mWeight);
+                        dropMap.addDrop(data.get(2), oreLayer.mWeight / 8f);
+                        dropMap.addDrop(data.get(3), oreLayer.mWeight / 8f);
+                    });
+        } catch (NullPointerException ignored) {}
+
+        // BW Small Ores
+        try {
+            GalacticGreg.smallOreWorldgenList.stream()
+                    .filter(
+                            gt_worldgen -> gt_worldgen.mEnabled
+                                    && gt_worldgen instanceof BW_Worldgen_Ore_SmallOre_Space smallOreSpace
+                                    && smallOreSpace.isEnabledForDim(finalDef))
+                    .map(gt_worldgen -> (BW_Worldgen_Ore_SmallOre_Space) gt_worldgen)
+                    .forEach(element -> dropMap.addDrop(element.mPrimaryMeta, element.mDensity, element.bwOres != 0));
+        } catch (NullPointerException ignored) {}
+        return dropMap;
+    }
+
+    public static void addBlockToDimensionList(int dimId, Block block, int meta, float weight) {
+        if (!extraDropsDimMap.containsKey(dimId)) {
+            extraDropsDimMap.put(dimId, new DropMap());
+        }
+        extraDropsDimMap.get(dimId).addDrop(block, meta, weight);
+    }
+
+    /**
+     * Public method giving other mods the ability to add manually a material with an ore version into the external
+     * dropMap for a specified dim id
+     *
+     * @param DimensionID the dim id targeted
+     * @param Material    the material with an ore version
+     * @param weight      the non normalised version of the given weight
+     */
+    public static void addMaterialToDimensionList(int DimensionID, ISubTagContainer Material, float weight) {
+        if (Material instanceof Materials gtMaterial) {
+            addBlockToDimensionList(DimensionID, GregTech_API.sBlockOres1, gtMaterial.mMetaItemSubID, weight);
+        } else if (Material instanceof Werkstoff werkstoff) {
+            addBlockToDimensionList(DimensionID, WerkstoffLoader.BWOres, werkstoff.getmID(), weight);
+        }
+    }
+}


### PR DESCRIPTION
Mainly moves ore and nobel gas data out of machine class.
No longer need to ~allocate and~ calculate a drop map everytime a miner is placed.
Adapts to https://github.com/GTNewHorizons/GT5-Unofficial/pull/2600.